### PR TITLE
Added quotes around FFMPEGPATH

### DIFF
--- a/bin/smp_project_generate_gpl3.bat
+++ b/bin/smp_project_generate_gpl3.bat
@@ -93,7 +93,7 @@ GOTO exit
 :makeGetDeps
 ECHO Creating project_get_dependencies.bat...
 FOR %%I IN %DEPENDENCIES% DO SET LASTDEP=%%I
-MKDIR %FFMPEGPATH%/SMP >NUL 2>&1
+MKDIR "%FFMPEGPATH%/SMP" >NUL 2>&1
 (
     ECHO @ECHO OFF
     ECHO SETLOCAL EnableDelayedExpansion

--- a/bin/smp_project_generate_lgpl3.bat
+++ b/bin/smp_project_generate_lgpl3.bat
@@ -88,7 +88,7 @@ GOTO exit
 :makeGetDeps
 ECHO Creating project_get_dependencies.bat...
 FOR %%I IN %DEPENDENCIES% DO SET LASTDEP=%%I
-MKDIR %FFMPEGPATH%/SMP >NUL 2>&1
+MKDIR "%FFMPEGPATH%/SMP" >NUL 2>&1
 (
     ECHO @ECHO OFF
     ECHO SETLOCAL EnableDelayedExpansion

--- a/bin/smp_project_generate_noredist.bat
+++ b/bin/smp_project_generate_noredist.bat
@@ -94,7 +94,7 @@ GOTO exit
 :makeGetDeps
 ECHO Creating project_get_dependencies.bat...
 FOR %%I IN %DEPENDENCIES% DO SET LASTDEP=%%I
-MKDIR %FFMPEGPATH%/SMP >NUL 2>&1
+MKDIR "%FFMPEGPATH%/SMP" >NUL 2>&1
 (
     ECHO @ECHO OFF
     ECHO SETLOCAL EnableDelayedExpansion
@@ -116,7 +116,7 @@ EXIT /B %ERRORLEVEL%
 :getDeps
 REM Add current repo to list of already passed dependencies
 ECHO Getting and updating any required dependency libs...
-cd %FFMPEGPATH%/SMP
+cd "%FFMPEGPATH%/SMP"
 CALL project_get_dependencies.bat "ffmpeg" || EXIT /B 1
 cd %~dp0
 ECHO.


### PR DESCRIPTION
Since you added quotes around `"%FFMPEGPATH%/SMP/project_get_dependencies.bat"`, I thought it would be consistent to do this with `mkdir` and `cd` too

Also, for some reason I had to do this, otherwise I got the error `file not found` when executing `MKDIR "%FFMPEGPATH%/SMP" >NUL 2>&1`, even though I didn't have spaces in my directory...
