### PR TITLE
Added --enable-libvpl support

### DIFF
--- a/source/configGenerator.cpp
+++ b/source/configGenerator.cpp
@@ -75,6 +75,18 @@ bool ConfigGenerator::passConfig(const int argc, char** argv)
     }
     // Super ensure forced values
     buildForcedValues();
+
+    // Force enable QSV
+    auto opt = getConfigOptionPrefixed("CONFIG_LIBVPL");
+    if ((opt != m_configValues.end()) && opt->m_value == "1") {
+        for (auto i = m_configValues.begin(); i != m_configValues.end(); ++i) {
+            string sTagName = i->m_prefix + i->m_option;
+            if (sTagName.find("QSV") != string::npos) {
+                i->m_value = "1";
+            }
+        }
+    }
+
     return true;
 }
 

--- a/source/projectGenerator.cpp
+++ b/source/projectGenerator.cpp
@@ -1455,7 +1455,7 @@ void ProjectGenerator::outputLibDirs(const StaticList& lib32Dirs, const StaticLi
             i += "%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>";
         }
         const string search[] = {"<Link>", "<Lib>"};
-        for (uint i = 0; i < 1; ++i) {
+        for (uint i = 0; i < 2; ++i) {
             uint arch32Or64 = 0; // start with 32 (assumes projects are ordered 32 then 64 recursive)
             uint findPos = projectTemplate.find(search[i]);
             while (findPos != string::npos) {

--- a/source/projectGenerator_build.cpp
+++ b/source/projectGenerator_build.cpp
@@ -195,6 +195,8 @@ void ProjectGenerator::buildDependencies(StaticList& libs, StaticList& addLibs, 
                 }
             } else if (i == "wincrypt") {
                 addLibs.push_back("Advapi32"); // Add the additional required libs
+            } else if (i == "libvpl") {
+                addLibs.push_back("vpl"); // Add the additional required libs
             } else {
                 // By default just use the lib name and prefix with lib if not already
                 if (i.find("lib") == 0) {
@@ -345,7 +347,7 @@ void ProjectGenerator::buildDependencyValues(StaticList& includeDirs, StaticList
                             "NVENC requires CUDA to be installed with NVENC headers made available in the CUDA SDK include path.",
                             false);
                     }
-                    // Only add if it hasn’t already been added
+                    // Only add if it hasnï¿½t already been added
                     if (find(includeDirs.begin(), includeDirs.end(), "$(CUDA_PATH)/include/") == includeDirs.end()) {
                         includeDirs.push_back("$(CUDA_PATH)/include/");
                     }
@@ -360,13 +362,22 @@ void ProjectGenerator::buildDependencyValues(StaticList& includeDirs, StaticList
                         outputWarning(
                             "Either the CUDA SDK is not installed or the environment variable is missing.", false);
                     }
-                    // Only add if it hasn’t already been added
+                    // Only add if it hasnï¿½t already been added
                     if (find(includeDirs.begin(), includeDirs.end(), "$(CUDA_PATH)/include/") == includeDirs.end()) {
                         includeDirs.push_back("$(CUDA_PATH)/include/");
                         lib32Dirs.push_back("$(CUDA_PATH)/lib/Win32");
                         lib64Dirs.push_back("$(CUDA_PATH)/lib/x64");
                     }
                 }
+            } else if (i.first == "libvpl" && !winrt) {
+                if (!findEnvironmentVariable("ONEAPI_ROOT")) {
+                    outputWarning("Could not find the OneAPI environment variable.");
+                    outputWarning(
+                        "Either the OneAPI SDK is not installed or the environment variable is missing.", false);
+                }
+                includeDirs.push_back("$(ONEAPI_ROOT)/vpl/latest/include/vpl/");
+                lib32Dirs.push_back("$(ONEAPI_ROOT)/vpl/latest/lib/x86");
+                lib64Dirs.push_back("$(ONEAPI_ROOT)/vpl/latest/lib");
             }
         }
     }
@@ -501,6 +512,10 @@ void ProjectGenerator::buildProjectDependencies(map<string, bool>& projectDeps) 
         (m_projectName == "libavdevice") || (m_projectName == "ffplay") || (m_projectName == "avplay");
     projectDeps["vapoursynth"] = m_projectName.compare("libavformat");
     projectDeps["zlib"] = (m_projectName == "libavformat") || (m_projectName == "libavcodec");
+    projectDeps["libvpl"] = ((m_projectName == "libavutil") && findSourceFile("hwcontext_qsv", ".h", notUsed)) ||
+        (m_projectName == "libavcodec") ||
+        ((m_projectName == "libavfilter") && findSourceFile("vf_deinterlace_qsv", ".c", notUsed)) ||
+        (m_projectName == "ffmpeg") || (m_projectName == "avconv");
 }
 
 void ProjectGenerator::buildProjectGUIDs(map<string, string>& keys) const


### PR DESCRIPTION
This involved force-enabling the QSV components manually.

Perhaps there is a better way? It's a bit confusing because the FFmpeg configure script references "libmfx" when identify the QSV dependencies, but if we enable this in the project generator then it requires its own headers/libs and it becomes something different than enabling libvpl.

It's a bit over my head, but after lots of trial and error I found this method works.
