### PR TITLE
Fixed av1_nvenc not being built with nvenc

### DIFF
--- a/source/configGenerator_build.cpp
+++ b/source/configGenerator_build.cpp
@@ -1074,6 +1074,8 @@ void ConfigGenerator::buildAdditionalDependencies(DependencyList& additionalDepe
         additionalDependencies["atomics_native"] = true;
     }
     additionalDependencies["MFX_CODEC_VP9"] = isConfigOptionEnabled("libmfx");
+    bool bNvenc = isConfigOptionEnabled("nvenc");
+    additionalDependencies["NV_ENC_PIC_PARAMS_AV1"] = bNvenc;
 }
 
 void ConfigGenerator::buildInterDependencies(InterDependencies& interDependencies)


### PR DESCRIPTION
The config system needs to check for NV_ENC_PIC_PARAMS_AV1 in order to enable the NVENC AV1 encoder.