### PR TITLE
Fix issue

### DIFF
--- a/bin/smp_project_get_dependencies
+++ b/bin/smp_project_get_dependencies
@@ -5,7 +5,7 @@ SET PASSDEPENDENCIES=%~1
 
 REM Check if git is installed and available
 IF "%MSVC_VER%"=="" (
-    WHERE git.exe >NUL
+    git status >NUL 2>&1
     IF ERRORLEVEL 1 (
         ECHO A working copy of git was not found. To use this script you must first install git for windows.
         GOTO exitOnError

--- a/bin/smp_project_get_dependencies
+++ b/bin/smp_project_get_dependencies
@@ -5,7 +5,7 @@ SET PASSDEPENDENCIES=%~1
 
 REM Check if git is installed and available
 IF "%MSVC_VER%"=="" (
-    git status >NUL 2>&1
+    WHERE git.exe >NUL
     IF ERRORLEVEL 1 (
         ECHO A working copy of git was not found. To use this script you must first install git for windows.
         GOTO exitOnError
@@ -69,7 +69,7 @@ IF EXIST "%REPONAME%" (
     REM  Once updated the repo needs to be reset to correct the local line endings
     cd %REPONAME%
     git config --local core.autocrlf false
-    git rm --cached -r . --quiet
+    git rm --cached --ignore-unmatch -r . --quiet
     git reset --hard --quiet
     cd ..\
 )


### PR DESCRIPTION
<!--- Provide a general summary of the enhancement in the Title above -->

## Context
<!--- Provide a more detailed introduction to the enhancement itself, and why you consider it to be useful -->

## Current and Suggested Behavior
<!--- Tell us what currently happens and then what this enhancement changes -->
Run smp_project_generate_gpl3.bat twice, get error "run smp_project_generate_gpl3.bat twice", because of "git rm --cached -r . --quiet".
It's ok when instead of "git rm --cached -r --ignore-unmatch . --quiet".

## Steps to Explain Enhancement
<!--- Provide an unambiguous set of steps to reproduce this bug such as command line arguments -->
1. unset MSVC_VER
2. smp_project_generate_gpl3.bat
3. smp_project_generate_gpl3.bat
4. get error "fatal: pathspec '.' did not match any files"

## Your Test Environment
<!--- Include as many relevant details about the environment you tested in -->
* Visual Studio Version Used: vs2022
* Operating System and Version(s): windows 10