### PR TITLE
add vaapi support

### DIFF
--- a/source/configGenerator_build.cpp
+++ b/source/configGenerator_build.cpp
@@ -462,6 +462,10 @@ bool ConfigGenerator::buildForcedValues()
         fastToggleConfigValue("w32threads", true);
     }
 
+    if (isConfigOptionEnabled("vaapi")) {
+        fastToggleConfigValue("vaapi_win32", true);
+    }
+
     return true;
 }
 
@@ -1037,7 +1041,9 @@ void ConfigGenerator::buildAdditionalDependencies(DependencyList& additionalDepe
     additionalDependencies["vdpau_vdpau_x11_h"] = false;
     additionalDependencies["vfw32"] = true;
     additionalDependencies["vfwcap_defines"] = true;
-    additionalDependencies["VADecPictureParameterBufferAV1_bit_depth_idx"] = false;
+    additionalDependencies["VAPictureParameterBufferHEVC"] = true;
+    additionalDependencies["VADecPictureParameterBufferVP9_bit_depth"] = true;
+    additionalDependencies["VADecPictureParameterBufferAV1_bit_depth_idx"] = true;
     additionalDependencies["VideoDecodeAcceleration_VDADecoder_h"] = false;
     additionalDependencies["X11_extensions_Xvlib_h"] = false;
     additionalDependencies["X11_extensions_XvMClib_h"] = false;
@@ -1048,13 +1054,14 @@ void ConfigGenerator::buildAdditionalDependencies(DependencyList& additionalDepe
     additionalDependencies["CUVIDHEVCPICPARAMS"] = bCuvid;
     additionalDependencies["CUVIDVC1PICPARAMS"] = bCuvid;
     additionalDependencies["CUVIDVP9PICPARAMS"] = bCuvid;
-    additionalDependencies["VAEncPictureParameterBufferH264"] = false;
+    additionalDependencies["VAEncPictureParameterBufferH264"] = true;
     additionalDependencies["videotoolbox_encoder"] = false;
-    additionalDependencies["VAEncPictureParameterBufferHEVC"] = false;
-    additionalDependencies["VAEncPictureParameterBufferJPEG"] = false;
-    additionalDependencies["VAEncPictureParameterBufferMPEG2"] = false;
-    additionalDependencies["VAEncPictureParameterBufferVP8"] = false;
-    additionalDependencies["VAEncPictureParameterBufferVP9"] = false;
+    additionalDependencies["VAEncPictureParameterBufferHEVC"] = true;
+    additionalDependencies["VAEncPictureParameterBufferJPEG"] = true;
+    additionalDependencies["VAEncPictureParameterBufferMPEG2"] = true;
+    additionalDependencies["VAEncPictureParameterBufferVP8"] = true;
+    additionalDependencies["VAEncPictureParameterBufferVP9"] = true;
+    additionalDependencies["VAEncPictureParameterBufferAV1"] = true;
     additionalDependencies["ole32"] = true;
     additionalDependencies["shell32"] = true;
     additionalDependencies["wincrypt"] = true;

--- a/source/projectGenerator_build.cpp
+++ b/source/projectGenerator_build.cpp
@@ -195,6 +195,10 @@ void ProjectGenerator::buildDependencies(StaticList& libs, StaticList& addLibs, 
                 }
             } else if (i == "wincrypt") {
                 addLibs.push_back("Advapi32"); // Add the additional required libs
+            } else if (i == "vaapi") {
+                addLibs.push_back("va");
+            } else if (i == "vaapi_win32") {
+                addLibs.push_back("va_win32");
             } else {
                 // By default just use the lib name and prefix with lib if not already
                 if (i.find("lib") == 0) {
@@ -504,6 +508,8 @@ void ProjectGenerator::buildProjectDependencies(map<string, bool>& projectDeps) 
     projectDeps["sdl"] = (m_projectName == "libavdevice") || (m_projectName == "ffplay") || (m_projectName == "avplay");
     projectDeps["sdl2"] =
         (m_projectName == "libavdevice") || (m_projectName == "ffplay") || (m_projectName == "avplay");
+    projectDeps["vaapi"] = (m_projectName == "libavcodec") || (m_projectName == "libavfilter") || (m_projectName == "libavutil");
+    projectDeps["vaapi_win32"] = (m_projectName == "libavcodec") || (m_projectName == "libavfilter") || (m_projectName == "libavutil");
     projectDeps["vapoursynth"] = m_projectName.compare("libavformat");
     projectDeps["zlib"] = (m_projectName == "libavformat") || (m_projectName == "libavcodec");
 }


### PR DESCRIPTION
VAAPI is now supported on Windows via the VAOn12 driver in mesa.

This PR enables support for the `--enable-vaapi` configure option. The compiled ffmpeg will support encode/decode through the VAAPI hwaccel.
