### PR TITLE
Adjust for FFFilter introduction

### DIFF
--- a/source/configGenerator.cpp
+++ b/source/configGenerator.cpp
@@ -1426,6 +1426,14 @@ bool ConfigGenerator::passFindFiltersExtern(const string& param1, vector<string>
         search = "extern const AVFilter ff_";
         start = findFile.find(search);
     }
+    if (start == string::npos) {
+        search = "extern FFFilter ff_";
+        start = findFile.find(search);
+    }
+    if (start == string::npos) {
+        search = "extern const FFFilter ff_";
+        start = findFile.find(search);
+    }
     while (start != string::npos) {
         // Find the start and end of the tag
         start += search.length();


### PR DESCRIPTION
There are additional oddities in the laterst ffmpeg master:

- DCE defs do not work for SIMD assembler stats for HEVC and SSE4, AVX512 etc.
  I had to entirely disable these things plus revert a related commit
- Code uses NaN at some places and MSVC compiler doesn't consider it as a constant
  So far, I've just changed the values to get past it